### PR TITLE
A few corrections

### DIFF
--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -316,8 +316,6 @@
 - Wandering Traders sell ink sacs with a damage value of 4
 
 - Leather Helmets with Efficiency 1 can be found in the tree room within Woodland Mansions
-
-- Black Glow Sticks can be found in a secret room within Woodland Mansions. The room contains a "Fake End Portal" and is completely hidden within the mansion's walls, with no visible indicators of its presence. This room always appears only on the mansion's first floor
 <br>
 
 
@@ -408,6 +406,8 @@
 - When a mob is left with only one heart and is simultaneously struck by an Instant Health Potion and an Instant Damage Potion, the mob becomes invincible. If the mob appears red and shaking, rejoining the game will restore its normal appearance
 
 - Zombies, Husks, Zombie Villagers, and Drowned can pick up Glow Ink Sacs
+
+- Black Glow Sticks can be found in a secret room within Woodland Mansions. The room contains a "Fake End Portal" and is completely hidden within the mansion's walls, with no visible indicators of its presence. This room always appears only on the mansion's first floor
 <br>
 
 

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -51,10 +51,6 @@
 - All types of buckets can stack up to 64. To prevent them from breaking, place these buckets directly into a chest before updating
 <br>
 
-### 0.8.0 alpha build 1: (Android Exclusive Version):
-- Placing a Coal Block in a Furnace and updating will turn that Coal Block into Nether Bricks
-<br>
-
 
 ### 0.8.0: (Android Exclusive Version)
 > [!NOTE]
@@ -76,6 +72,8 @@
 - Carpets can be placed underwater
 
 - Placing logs sideways and breaking them will drop sideways logs
+
+- Placing a Coal Block in a Furnace and updating will turn that Coal Block into Nether Bricks
 <br>
 
 

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -39,8 +39,6 @@
 
 
 ### 0.6.0: (Android Exclusive Version)
-- Any cake blocks that are placed, will convert to info_update2 in the next version. These blocks can be mined with any tool and will drop themselves
-
 - Top-half slabs are obtainable by placing slabs on the upper half and breaking them
 
 - Placing a slab adjacent to the world border and attempting to place a block that needs support (e.g. torches) on the side of the slab will result in the support block facing towards the world border
@@ -56,6 +54,8 @@
 > [!NOTE]
 > This discontinued feature can only be seen by using third-party tools or checking the files in the world folder.
 - Loading a world creates a "players" folder in the world files. 
+
+- Any beetroot crops that are placed, will convert to info_update2 in the next version. These blocks can be mined with any tool and will drop themselves
 
 - Items can be overstacked by opening your world to LAN and connecting with a second device. If a second device isn’t available, you can use apps like [Parallel Space](https://play.google.com/store/apps/details?id=com.lbe.parallel.intl) to run multiple minecraft instances. Drop the items to the second device and relog on the host device after 10 seconds. This process makes item stacks go over 99, and sometimes over 255, which causes them to overflow into a negative value. In the game, though, negative stacks will still show as 99+
 


### PR DESCRIPTION
1.17.0 is the earliest stable version where black glow sticks generate. In 1.16.201, the fake end portal room generates with leads instead.

0.8.0 alpha build 1 and 0.8.0_test1 are the same version; the former is simply what the version is named on the Minecraft Wiki. The one DF listed under the former has been merged into the latter.

The guide previously did not indicate that cake is not a legitimately obtainable block in 0.6.0, nor that downgrading is required to convert cake to info_update2, which could cause readers to incorrectly conclude that cake converts to info_update2 upon updating from 0.6.0 to 0.7.1. Instead, we use 0.8.0 -> 0.8.0_test1 to obtain the block as that's a downgrade already built into the guide. Since cake does not convert to info_update2 using this downgrade, we swap it out for beetroot crops.