### PR TITLE
Seven changes

### DIFF
--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -508,7 +508,7 @@
 <br>
 
 
-Beta 1.18.20.21: (Requires "Wild Update" World Toggle)
+### Beta 1.18.20.21: (Requires "Wild Update" World Toggle)
 > [!NOTE]
 > This discontinued feature can only be seen by using third-party tools or checking the files in the world folder.
 - Previously placed frog spawn will turn into unknown blocks, storing the old "minecraft:frog_egg" ID

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -77,12 +77,13 @@
 <br>
 
 
-### 0.12.1: (Android Exclusive Version)
-- Placing sponge underwater won't make it absorb any water
-
-- Renaming any item in an anvil adds an anvil use, increasing its cost with each renaming
-
+### 0.12.1 build 3: (Android Exclusive Version)
 - Blowing up a chest with enchanted books inside will remove the data of the enchanted books, leaving behind plain Enchanted Books with no enchantments
+<br>
+
+
+### 0.12.1: (Android Exclusive Version)
+- Renaming any item in an anvil adds an anvil use, increasing its cost with each renaming
 <br>
 
 
@@ -95,12 +96,20 @@
 
 ### 0.15.9:
 - Iron golems do not have knockback resistance
+
 - Taming Cats in this version and leaving them in unloaded chunks until 1.8.0.8 will turn them into tamed ocelots. In modern versions, they cannot be interacted with, which means you can't make them stand if they're sitting, or sit if they're standing
 <br>
 
 
 ### 0.16.0 build 4: (Android Exclusive Version)
 - When anvils fall onto torches, they drop with different data values (0–11) depending on their damage level and rotation
+
+- Sponges can be found inside ocean monuments, which is required for the next version
+<br>
+
+
+### 0.14.3:
+- Placing sponge underwater won't make it absorb any water
 <br>
 
 

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -356,7 +356,7 @@
 
 
 ### Beta 1.17.0.52: (Android Exclusive Version, Requires "Caves and Cliffs" World Toggle)
-- All chunks that are loaded with the experimental toggle enabled will be elevated when updating. Any tile entity data in these chunks will be removed, which can result in things like empty mob spawners
+- All chunks that are loaded with the experimental toggle enabled will be elevated when updating. Any tile entity data in these chunks is not elevated accordingly, which can result in things like empty mob spawners
 <br>
 
 

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -101,7 +101,7 @@
 <br>
 
 
-### 0.16.0 build 4: (Android Exclusive Version)
+### 0.16.0 build 3: (Android Exclusive Version)
 - When anvils fall onto torches, they drop with different data values (0–11) depending on their damage level and rotation
 
 - Sponges can be found inside ocean monuments, which is required for the next version

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -108,11 +108,6 @@
 <br>
 
 
-### 0.16.0: (Android Exclusive Version)
-- Shearing mooshrooms drops mushrooms with a damage value of -1
-<br>
-
-
 ### alpha 0.17.0.1: (Android Exclusive Version)
 > [!CAUTION]
 > Hitting mobs crashes the game.

--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -77,11 +77,6 @@
 <br>
 
 
-### 0.12.0:
-- Iron golems do not have knockback resistance
-<br>
-
-
 ### 0.12.1: (Android Exclusive Version)
 - Placing sponge underwater won't make it absorb any water
 
@@ -99,6 +94,7 @@
 
 
 ### 0.15.9:
+- Iron golems do not have knockback resistance
 - Taming Cats in this version and leaving them in unloaded chunks until 1.8.0.8 will turn them into tamed ocelots. In modern versions, they cannot be interacted with, which means you can't make them stand if they're sitting, or sit if they're standing
 <br>
 


### PR DESCRIPTION
1. Negative damage value mushrooms convert to dv0 starting in 1.1.0.0, so those have been removed.
2. Change wording for the elevated chunks glitch. It doesn't outright delete block entity data, it just doesn't shift that data upwards with the rest of the chunk. This can be observed in-game by placing an empty chest 64 blocks below a filled chest. Once this glitch is performed, the top chest's contents "shift" to the lower one.
3. Formatting fix for the beta 1.18.20.21 header.
4. 0.12.0 is the one Windows 10 exclusive version used in this guide. Knockback iron golems have been moved to a later version to eliminate this.
5. The glitch allowing for no nbt enchanted books was patched in 0.12.1-b6, so that has been moved to an earlier version. Build 3 was chosen as it is the build where the player is the least likely to encounter annoying bugs.
6. Sponges are not legitimately obtainable in 0.12.1, so a downgrade to 0.14.3 has been added to the version path to allow the player to properly obtain dry sponges in water. Why not downgrade to 0.15.x? Because the game crashes on startup if you try doing that.
7. The version used to obtain idv anvils has been pushed back by one build for two reasons. The first is that this makes the aforementioned downgrade to 0.14.3 less damaging - most passive mobs in a world are deleted upon downgrading below 0.16.0-b4. The second is that 0.16.0-b4 is just riddled with bugs regardless of any downgrade shenanigans, and it should be avoided as long as there is not any dfs that require that version to be obtained.