### PR TITLE
remove unintended external editing

### DIFF
--- a/Bedrock/Guide.md
+++ b/Bedrock/Guide.md
@@ -82,7 +82,7 @@
 <br>
 
 
-### 0.12.1: (Android Exclusive Version)
+### 0.14.0 build 2: (Android Exclusive Version)
 - Renaming any item in an anvil adds an anvil use, increasing its cost with each renaming
 <br>
 


### PR DESCRIPTION
I forgot that NetworkVersion was a thing for a second. Updating from 0.12.1 to 0.15.2 sets its value to 81, which makes downgrading from 0.16.0-b3 to 0.14.3 impossible without external editing. By moving rename repair cost to 0.14.0-b2, NetworkVersion's value instead gets set to 41 when we update to that version, meaning the player won't experience any issues with performing the aforementioned downgrade.